### PR TITLE
Feat  tableclient api default behavior

### DIFF
--- a/samples/Azure.EntityServices.Samples/TableSample.cs
+++ b/samples/Azure.EntityServices.Samples/TableSample.cs
@@ -12,7 +12,7 @@ namespace Azure.EntityServices.Samples
 {
     public static class TableSample
     {
-        private const int ENTITY_COUNT = 1000;
+        private const int ENTITY_COUNT = 100;
 
         public static async Task Run()
         {
@@ -20,8 +20,11 @@ namespace Azure.EntityServices.Samples
             var tenants = new string[] { "tenant1", "tenant2", "tenant3", "tenant4", "tenant5" };
 
             //default options with up to 10 parallel transactions to be processed by the pipeline
-            var options = new EntityTableClientOptions(TestEnvironment.ConnectionString,
-                $"{nameof(PersonEntity)}");
+            var options = new EntityTableClientOptions(
+                TestEnvironment.ConnectionString,
+                $"{nameof(PersonEntity)}",
+                createTableIfNotExists: true,
+                enableIndexedTagSupport:true);
             //Configure entity binding in the table storage
             //partition key as TenantId property
             //primary key as PersonId property

--- a/src/Azure.EntityServices.Tables/Core/TableQueryHelper.cs
+++ b/src/Azure.EntityServices.Tables/Core/TableQueryHelper.cs
@@ -1,27 +1,29 @@
 ﻿using Azure.EntityServices.Tables.Extensions;
 using System;
-using System.Globalization;
 using System.Text;
 
 namespace Azure.EntityServices.Tables.Core
 {
     public static class TableQueryHelper
     {
-        public static string ToRowKey<P>(string tagName, P value) =>
-            $"{tagName}-{KeyValueToString(value)}";
-         
+        public static string ToPrimaryRowKey<P>(P value) =>
+            KeyValueToString(value);
+
+        public static string ToTagRowKeyPrefix<P>(string tagName, P value) =>
+            $"~{tagName}-{KeyValueToString(value)}$";
+
         public static string ValueToString<P>(P givenValue)
         {
             return givenValue switch
             {
                 bool v => v ? "true" : "false",
                 float => $"'{givenValue.ToInvariantString()}'",
-                decimal =>$"'{givenValue.ToInvariantString()}'" ,
+                decimal => $"'{givenValue.ToInvariantString()}'",
                 double => givenValue.ToInvariantString(),
                 int => givenValue.ToInvariantString(),
                 long => string.Format("{0}L", givenValue),
                 byte[] v => ByteArrayToString(v),
-                DateTime v => string.Format("datetime'{0}'", (v==default)? TableConstants.DateTimeStorageDefault.ToString("o") :v.ToUniversalTime().ToString("o")),
+                DateTime v => string.Format("datetime'{0}'", (v == default) ? TableConstants.DateTimeStorageDefault.ToString("o") : v.ToUniversalTime().ToString("o")),
                 DateTimeOffset v => string.Format("datetime'{0}'", (v == default) ? new DateTimeOffset(TableConstants.DateTimeStorageDefault).UtcDateTime.ToString("o") : v.UtcDateTime.ToString("o")),
                 Guid v => string.Format("guid'{0}'", v),
                 BinaryData v => string.Format("X'{0}'", v),
@@ -33,12 +35,12 @@ namespace Azure.EntityServices.Tables.Core
         {
             return givenValue switch
             {
-                bool v => v ? "true" : "false",  
+                bool v => v ? "true" : "false",
                 long => string.Format("{0}L", givenValue),
-                byte[] v => ByteArrayToString(v), 
+                byte[] v => ByteArrayToString(v),
                 Guid v => string.Format("{0}", v),
                 BinaryData v => string.Format("X{0}", v),
-              
+
                 _ => givenValue == null ? "" : $"{givenValue.ToInvariantString()}"
             };
         }

--- a/src/Azure.EntityServices.Tables/Queries/ITagQueryFilterExtensions.cs
+++ b/src/Azure.EntityServices.Tables/Queries/ITagQueryFilterExtensions.cs
@@ -11,17 +11,17 @@ namespace Azure.EntityServices.Tables
         public static IFilterOperator<T> Between<T, P>(this ITagQueryFilter<T, P> query, P minValue,P maxValue)
         {
             return (query as IQueryFilter<T>)
-                  .GreaterThan($"{TableQueryHelper.ToRowKey(query.TagName, minValue)}$")
+                  .GreaterThan($"{TableQueryHelper.ToTagRowKeyPrefix(query.TagName, minValue)}")
                   .And($"RowKey")
-                  .LessThan($"{TableQueryHelper.ToRowKey(query.TagName, maxValue)}$~")
+                  .LessThan($"{TableQueryHelper.ToTagRowKeyPrefix(query.TagName, maxValue)}~")
                   .And(EntitytableConstants.DeletedTag).Equal(false);
         }
         public static IFilterOperator<T> Equal<T, P>(this ITagQueryFilter<T, P> query, P value)
         {
             return (query as IQueryFilter<T>)
-                  .GreaterThan($"{TableQueryHelper.ToRowKey(query.TagName, value)}$")
+                  .GreaterThan($"{TableQueryHelper.ToTagRowKeyPrefix(query.TagName, value)}")
                   .And($"RowKey")
-                  .LessThan($"{TableQueryHelper.ToRowKey(query.TagName, value)}$~")
+                  .LessThan($"{TableQueryHelper.ToTagRowKeyPrefix(query.TagName, value)}~")
                   .And(EntitytableConstants.DeletedTag).Equal(false);
         }
      
@@ -29,35 +29,35 @@ namespace Azure.EntityServices.Tables
         public static IFilterOperator<T> GreaterThan<T, P>(this ITagQueryFilter<T, P> query, P value)
         {
             return (query as IQueryFilter<T>)
-               .GreaterThan($"{TableQueryHelper.ToRowKey(query.TagName, value)}$~")
+               .GreaterThan($"{TableQueryHelper.ToTagRowKeyPrefix(query.TagName, value)}~")
                .And($"RowKey")
-               .LessThan($"{query.TagName}-~")
+               .LessThan($"~{query.TagName}-~")
                .And(EntitytableConstants.DeletedTag).Equal(false);
         }
 
         public static IFilterOperator<T> GreaterThanOrEqual<T, P>(this ITagQueryFilter<T> query, P value)
         {
             return (query as IQueryFilter<T>)
-               .GreaterThan($"{TableQueryHelper.ToRowKey(query.TagName,value)}$")
+               .GreaterThan($"{TableQueryHelper.ToTagRowKeyPrefix(query.TagName,value)}")
                .And($"RowKey")
-               .LessThan($"{query.TagName}-~")
+               .LessThan($"~{query.TagName}-~")
                .And(EntitytableConstants.DeletedTag).Equal(false);
         }
         public static IFilterOperator<T> LessThan<T, P>(this ITagQueryFilter<T> query, P value)
         {
             return (query as IQueryFilter<T>)
-               .GreaterThan($"{query.TagName}-")
+               .GreaterThan($"~{query.TagName}-")
                .And($"RowKey")
-               .LessThan($"{TableQueryHelper.ToRowKey(query.TagName, value)}$")
+               .LessThan($"{TableQueryHelper.ToTagRowKeyPrefix(query.TagName, value)}")
                .And(EntitytableConstants.DeletedTag).Equal(false);
         }
 
         public static IFilterOperator<T> LessThanOrEqual<T, P>(this ITagQueryFilter<T> query, P value)
         {
             return (query as IQueryFilter<T>)
-               .GreaterThan($"{query.TagName}-")
+               .GreaterThan($"~{query.TagName}-")
                .And($"RowKey")
-               .LessThan($"{TableQueryHelper.ToRowKey(query.TagName, value)}$~")
+               .LessThan($"{TableQueryHelper.ToTagRowKeyPrefix(query.TagName, value)}~")
                .And(EntitytableConstants.DeletedTag).Equal(false);
         }
      

--- a/tests/Azure.EntityServices.Tests/QueryExpressions/TableStorageQueryBuilderTests.cs
+++ b/tests/Azure.EntityServices.Tests/QueryExpressions/TableStorageQueryBuilderTests.cs
@@ -61,7 +61,7 @@ namespace Azure.EntityServices.Table.Tests
 
             queryStr.Trim()
                 .Should()
-                .Be("RowKey gt 'Created-2022-10-22$' and RowKey lt 'Created-2022-10-22$~' and _deleted_tag_ eq false and TenantId eq '10'");
+                .Be("RowKey gt '~Created-2022-10-22$' and RowKey lt '~Created-2022-10-22$~' and _deleted_tag_ eq false and TenantId eq '10'");
         }
 
         [TestMethod]
@@ -77,7 +77,7 @@ namespace Azure.EntityServices.Table.Tests
 
             queryStr.Trim()
                 .Should()
-                .Be("RowKey gt 'Created-2022-10-22$' and RowKey lt 'Created-~' and _deleted_tag_ eq false and TenantId eq '10'");
+                .Be("RowKey gt '~Created-2022-10-22$' and RowKey lt '~Created-~' and _deleted_tag_ eq false and TenantId eq '10'");
         }
 
         [TestMethod]
@@ -93,7 +93,7 @@ namespace Azure.EntityServices.Table.Tests
 
             queryStr.Trim()
                 .Should()
-                .Be("RowKey gt 'Created-' and RowKey lt 'Created-2022-10-22$~' and _deleted_tag_ eq false and TenantId eq '10'");
+                .Be("RowKey gt '~Created-' and RowKey lt '~Created-2022-10-22$~' and _deleted_tag_ eq false and TenantId eq '10'");
         }
 
         [TestMethod]
@@ -112,7 +112,7 @@ namespace Azure.EntityServices.Table.Tests
 
             queryStr.Trim()
                 .Should()
-                .Be("RowKey gt 'Created-$' and RowKey lt 'Created-$~' and _deleted_tag_ eq false and TenantId eq '10' and Created eq null or Enabled eq null or Altitude eq null");
+                .Be("RowKey gt '~Created-$' and RowKey lt '~Created-$~' and _deleted_tag_ eq false and TenantId eq '10' and Created eq null or Enabled eq null or Altitude eq null");
         }
 
         [TestMethod]
@@ -132,7 +132,7 @@ namespace Azure.EntityServices.Table.Tests
 
             queryStr.Trim()
                 .Should()
-                .Be("RowKey gt 'Created-$' and RowKey lt 'Created-$~' and _deleted_tag_ eq false and TenantId eq '10' and Updated eq datetime'1601-01-01T00:00:00.0000000Z' and LocalUpdated eq datetime'1601-01-01T00:00:00.0000000Z' or Enabled eq null or Altitude eq null");
+                .Be("RowKey gt '~Created-$' and RowKey lt '~Created-$~' and _deleted_tag_ eq false and TenantId eq '10' and Updated eq datetime'1601-01-01T00:00:00.0000000Z' and LocalUpdated eq datetime'1601-01-01T00:00:00.0000000Z' or Enabled eq null or Altitude eq null");
                     
         }
 


### PR DESCRIPTION
Changed internal naming policy in table client to simplify integration of this sdk with existing table data

- Preserve primary row key value (no prefix , no suffix)

- Tags row keys will be always filtered by default even if index tag feature was disabled
